### PR TITLE
Change device name to drogueroids controller

### DIFF
--- a/firmware/app/src/main.rs
+++ b/firmware/app/src/main.rs
@@ -61,7 +61,7 @@ async fn main(s: Spawner) {
     let board = Microbit::new(config());
 
     // Spawn the underlying softdevice task
-    let sd = enable_softdevice("Drogue Presenter");
+    let sd = enable_softdevice("drogueroids controller");
 
     let version = FIRMWARE_REVISION.unwrap_or(FIRMWARE_VERSION);
     defmt::info!("Running firmware version {}", version);
@@ -71,7 +71,7 @@ async fn main(s: Spawner) {
     let server = GATT.init(GattServer::new(sd).unwrap());
     server
         .device_info
-        .initialize(b"Drogue Presenter", b"1.0", b"Red Hat", b"1.0")
+        .initialize(b"drogueroids controller", b"1.0", b"Red Hat", b"1.0")
         .unwrap();
     server
         .env
@@ -140,7 +140,7 @@ async fn main(s: Spawner) {
         EVENTS.sender().into(),
         BUTTONS.receiver().into(),
         XL_CHAN.receiver().into(),
-        "Drogue Presenter",
+        "drogueroids controller",
     ))
     .unwrap();
 }

--- a/js/ble.js
+++ b/js/ble.js
@@ -51,7 +51,7 @@ class BleConnector {
 
         const device = await navigator.bluetooth.requestDevice({
             filters: [
-                {name: "Drogue Presenter"}
+                {name: "drogueroids controller"}
             ],
             optionalServices: [
                 BUTTONS_SERVICE,


### PR DESCRIPTION
This commit changes the name of the device from "Drogue Presenter" to "drogueroids controller" which seems more descriptive of the usage of the device in this case.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>