### PR TITLE
Add a note about enabling bluetooth in Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 We come in peace.
 
 Download the [firmware for your microbit](https://github.com/drogue-iot/drogueroids/releases), copy it to the microbit, and launch the [game](https://drogue-iot.github.io/drogueroids/) in a browser to get started.
+
+## Bluetooth in Chrome
+To run the game Bluetooth needs to be enabled in Chrome. This can be done by
+typing `chrome://flags/#enable-web-bluetooth-new-permissions-backend` in the
+browsers address field, and the selecting `Enabled` from the drop down
+menu.


### PR DESCRIPTION
This commit adds a note about how to enable bluetooth in Chrome.

The motivation for this is that I had to enable this and others might as well, and this will save them having to search for how to do that (which might turn them off of trying out the game).

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>